### PR TITLE
S129.00 Remove check if table exists.

### DIFF
--- a/Lib/MongoTableNotFoundException.php
+++ b/Lib/MongoTableNotFoundException.php
@@ -1,7 +1,0 @@
-<?php
-namespace CakePHPUtil\Lib;
-
-/**
- * Class MongoTableNotFoundException
- */
-class MongoTableNotFoundException extends \Exception {}

--- a/Model/Behavior/MongoBehavior.php
+++ b/Model/Behavior/MongoBehavior.php
@@ -26,17 +26,6 @@ class MongoBehavior extends ModelBehavior {
 	}
 
 /**
- * Check if the current table exists.
- *
- * @return bool
- */
-	protected function _tableExists($model) {
-		return $model->getDataSource()->getMongoDb()->system->namespaces->findOne(array(
-			'name' => $model->getDataSource()->config['database'] . '.' . $model->useTable
-		)) != null;
-	}
-
-/**
  * Group by method.
  *
  * @param array $field

--- a/Model/Behavior/MongoBehavior.php
+++ b/Model/Behavior/MongoBehavior.php
@@ -1,6 +1,4 @@
 <?php
-use CakePHPUtil\Lib\MongoTableNotFoundException;
-
 App::import('Vendor', 'ModelBehavior', array(
 	'file' => 'cakephp' . DS . 'cakephp' . DS . 'lib' . DS . 'Cake' . DS . 'Model' . DS . 'ModelBehavior.php'
 ));
@@ -23,14 +21,6 @@ class MongoBehavior extends ModelBehavior {
 	public function dropTable($model) {
 		if (!$model->useTable) {
 			return;
-		}
-		$mongo = $model->getDataSource()->getMongoDb();
-		$table = (is_object($mongo) && $this->_tableExists($model))
-			? $model->getDataSource()->getMongoDb()->{$model->useTable}
-			: null;
-		if (is_null($table)) {
-			//Note that this exception prevents a Fatal Error on the line below.
-			throw new MongoTableNotFoundException(sprintf('Tried to delete Table %s, but it does not exist', $model->useTable));
 		}
 		$model->getDataSource()->getMongoDb()->{$model->useTable}->drop();
 	}


### PR DESCRIPTION
Mongodb 3.0+ in combination with the WiredTiger storage engine doesn't throw an error when dropping a table that does not exist.

Querying the system namespace also doesnt work anymore.